### PR TITLE
fix: vault_roles will be known only after apply

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -1,5 +1,9 @@
+locals {
+  owner = coalesce(var.owner, var.database)
+}
+
 resource "postgresql_role" "owner" {
-  name     = coalesce(var.owner, var.database)
+  name     = local.owner
   login    = var.owner_password != null ? true : false
   password = var.owner_password
   roles    = var.roles

--- a/vault.tf
+++ b/vault.tf
@@ -1,8 +1,8 @@
 locals {
   vault_roles = var.vault_backend_path == "" ? {} : {
-    "${postgresql_role.owner.name}"       = postgresql_role.owner.name
-    "${postgresql_database.this.name}-ro" = postgresql_role.read_only.name
-    "${postgresql_database.this.name}-rw" = postgresql_role.read_write.name
+    "${local.owner}"     = postgresql_role.owner.name
+    "${var.database}-ro" = postgresql_role.read_only.name
+    "${var.database}-rw" = postgresql_role.read_write.name
   }
 }
 


### PR DESCRIPTION
Terraform in confused when doing a plan as an output is used to create other stuff

```console
│ Error: Invalid for_each argument
│
│   on .terraform/modules/hippo/vault.tf line 10, in resource "vault_database_secret_backend_role" "owner":
│   10:   for_each = local.vault_roles
│     ├────────────────
│     │ local.vault_roles will be known only after apply
│
│ The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many
│ instances will be created. To work around this, use the -target argument to first apply only the resources that the for_each depends
│ on.
╵
╷
│ Error: Invalid for_each argument
│
│   on .terraform/modules/hippo/vault.tf line 33, in data "vault_policy_document" "this":
│   33:   for_each = local.vault_roles
│     ├────────────────
│     │ local.vault_roles will be known only after apply
│
│ The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many
│ instances will be created. To work around this, use the -target argument to first apply only the resources that the for_each depends
│ on.
╵
Releasing state lock. This may take a few moments...
```