### PR TITLE
fix: escape the role and database names

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In particular:
 
 ```hcl
 module "foo" {
-  source = "git@github.com:edgelaboratories/terraform-postgresql-db?ref=v0.4.2"
+  source = "git@github.com:edgelaboratories/terraform-postgresql-db?ref=v0.4.3"
 
   database       = "foo"
   owner          = "admin"  # Optional, default to database name

--- a/vault.tf
+++ b/vault.tf
@@ -14,10 +14,10 @@ resource "vault_database_secret_backend_role" "owner" {
   db_name = var.vault_db_connection_name
 
   creation_statements = concat([
-    "CREATE ROLE \"{{name}}\" IN ROLE ${each.value} LOGIN PASSWORD '{{password}}' INHERIT VALID UNTIL '{{expiration}}';",
+    "CREATE ROLE \"{{name}}\" IN ROLE \"${each.value}\" LOGIN PASSWORD '{{password}}' INHERIT VALID UNTIL '{{expiration}}';",
 
     # Automatically SET ROLE to db owner at login
-    "ALTER ROLE \"{{name}}\" IN DATABASE ${postgresql_database.this.name} SET ROLE ${each.value}",
+    "ALTER ROLE \"{{name}}\" IN DATABASE \"${postgresql_database.this.name}\" SET ROLE \"${each.value}\";",
   ])
 
   renew_statements = [


### PR DESCRIPTION
It breaks when the database contains an hypen (-).