### PR TITLE
feat: Add optional capacities to `owner`

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -5,8 +5,8 @@ locals {
 resource "postgresql_role" "owner" {
   name            = local.owner
   login           = var.owner_password != null ? true : false
-  create_database = var.owner_create_database != null ? true : false
-  create_role     = var.owner_create_role != null ? true : false
+  create_database = var.owner_create_database
+  create_role     = var.owner_create_role
   password        = var.owner_password
   roles           = var.roles
 

--- a/database.tf
+++ b/database.tf
@@ -3,10 +3,12 @@ locals {
 }
 
 resource "postgresql_role" "owner" {
-  name     = local.owner
-  login    = var.owner_password != null ? true : false
-  password = var.owner_password
-  roles    = var.roles
+  name            = local.owner
+  login           = var.owner_password != null ? true : false
+  create_database = var.owner_create_database != null ? true : false
+  create_role     = var.owner_create_role != null ? true : false
+  password        = var.owner_password
+  roles           = var.roles
 
   connection_limit = var.connection_limit
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,16 @@ variable "owner" {
   default     = ""
 }
 
+variable "owner_create_database" {
+  description = "Defines a role's ability to execute `CREATE DATABASE`"
+  default     = null
+}
+
+variable "owner_create_role" {
+  description = "Defines a role's ability to execute `CREATE ROLE`. A role with this privilege can also alter and drop other roles."
+  default     = null
+}
+
 variable "owner_password" {
   description = "The password for the owner of the database"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,12 @@ variable "owner" {
 
 variable "owner_create_database" {
   description = "Defines a role's ability to execute `CREATE DATABASE`"
-  default     = null
+  default     = false
 }
 
 variable "owner_create_role" {
   description = "Defines a role's ability to execute `CREATE ROLE`. A role with this privilege can also alter and drop other roles."
-  default     = null
+  default     = false
 }
 
 variable "owner_password" {


### PR DESCRIPTION
This PR adds 2 optional capacities to the db owner:

* Create DB
* Create Role

This is needed by `Ledger` project: One of the services will dynamically create DB and users for the others services to use it.

Default values are set to `false`, meaning no changes are needed on other resources using this module.